### PR TITLE
Store snapshots in localStorage and prefetch from gateway

### DIFF
--- a/src/components/SnapshotLink.js
+++ b/src/components/SnapshotLink.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const GATEWAY_PREFIX = 'https://gateway.ipfs.io/ipfs'
+
+export const toSnapshotUrl = ({hash, key, gateway = GATEWAY_PREFIX}) => `${gateway}/${hash}/#${key}`
+
+const SnapshotLink = ({snapshot, className, style, target = '_blank', children}) => (
+  <a href={toSnapshotUrl(snapshot)} className={className} style={style} target={target}>
+    {children || snapshot.hash}
+  </a>
+)
+
+export default SnapshotLink

--- a/src/components/toolbar/buttons/SnapshotsButton.js
+++ b/src/components/toolbar/buttons/SnapshotsButton.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Button from './Button'
+import SnapshotLink from '../../SnapshotLink'
 import { SnapshotIcon } from '../../icons'
 import { Dropleft, DropleftMenu } from '../../dropdown/Dropleft'
-
-const GATEWAY_PREFIX = 'https://gateway.ipfs.io/ipfs'
 
 export default class SnapshotsButton extends Component {
   constructor (props) {
@@ -41,16 +40,13 @@ export default class SnapshotsButton extends Component {
             {snapshots.length ? (
               <ul className='list ma0 pa0'>
                 {snapshots.map((ss) => {
-                  console.log(ss)
-                  const url = `${GATEWAY_PREFIX}/${ss.hash}/#${ss.key}`
                   return (
-                    <li key={url} className='mb3'>
-                      <small className='db mb1 f7 fw5 pigeon-post'>[timestamp]</small>
-                      <a href={url}
+                    <li key={ss.hash} className='mb3'>
+                      <small className='db mb1 f7 fw5 pigeon-post'>{ss.createdAt}</small>
+                      <SnapshotLink
+                        snapshot={ss}
                         className='f7 big-stone db code'
-                        style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                        {ss.hash}
-                      </a>
+                        style={{ overflow: 'hidden', textOverflow: 'ellipsis' }} />
                     </li>
                   )
                 })}

--- a/src/components/toolbar/buttons/SnapshotsButton.js
+++ b/src/components/toolbar/buttons/SnapshotsButton.js
@@ -36,16 +36,18 @@ export default class SnapshotsButton extends Component {
     return (
       <Dropleft>
         <Button theme={theme} icon={SnapshotIcon} title='Snapshots' onClick={onDropleftTriggerClick} />
-        <DropleftMenu width={300} height={77} open={dropleftMenuOpen} onDismiss={onDropleftMenuDismiss}>
-          <div className='pa3'>
+        <DropleftMenu width={400} height={80} open={dropleftMenuOpen} onDismiss={onDropleftMenuDismiss}>
+          <div className='pa4'>
             {snapshots.length ? (
               <ul className='list ma0 pa0'>
                 {snapshots.map((ss) => {
+                  console.log(ss)
                   const url = `${GATEWAY_PREFIX}/${ss.hash}/#${ss.key}`
                   return (
-                    <li key={url} className='mb2'>
+                    <li key={url} className='mb3'>
+                      <small className='db mb1 f7 fw5 pigeon-post'>[timestamp]</small>
                       <a href={url}
-                        className='f6 big-stone db'
+                        className='f7 big-stone db code'
                         style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
                         {ss.hash}
                       </a>
@@ -56,7 +58,7 @@ export default class SnapshotsButton extends Component {
             ) : (
               <p className='f7 mt0 mb2 tc'>No snapshots taken</p>
             )}
-            <div className='tc'>
+            <div className='tc pt3'>
               <button type='button' className='button-reset f7 white-lilac bg-bright-turquoise hover--white ba b--bright-turquoise ph2 pv1 bw0 ttu pointer br1' onClick={onTakeSnapshot}>Take Snapshot</button>
             </div>
           </div>


### PR DESCRIPTION
- Tweak snapshot ui to show timestamp and give enough space to see full hash, and use a monospace font to make the length predictable.
- Store and load snapshots from localStorage to persist them across sessions.
- Prefetch snapshots from gateway to speed up first render.
- Add local `createdAt` time property to snapshots. (ISO 8601 string)
- Adds `title` property which is now the mutable doc title. `name` is immutable and part of the url.  See: #62 

![screenshot 2017-10-25 19 05 54](https://user-images.githubusercontent.com/58871/32015349-c03c7f82-b9b8-11e7-83e8-c7156a257369.png)

Fixes #56 
Fixes #54 