### PR TITLE
Styles for published snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "history": "^4.7.2",
     "html-webpack-plugin": "2.29.0",
     "jest": "20.0.4",
+    "normalize.css": "^7.0.0",
     "object-assign": "4.1.1",
     "peerpad-core": "^0.4.0",
     "postcss-css-variables": "^0.8.0",

--- a/src/colors.css
+++ b/src/colors.css
@@ -2,6 +2,7 @@
 :root {
   --blue-bayox: #50617B;
   --bright-turquoise: #23e0f7;
+  --dull-turquoise: #1fccdf;
   --caribbean-green: #02caad;
   --cloud-burst: #233855;
   --dove-gray: #656464;

--- a/src/components/Doc.css
+++ b/src/components/Doc.css
@@ -1,0 +1,124 @@
+@import '../colors.css';
+
+.Doc {
+  color: var(--firefly);
+  line-height: 1.5;
+  font-size: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "avenir next", avenir, helvetica, "helvetica neue", ubuntu, roboto, noto, "segoe ui", arial, sans-serif;
+}
+
+.Doc h1,
+.Doc h2,
+.Doc h3,
+.Doc h4,
+.Doc h5,
+.Doc h6 {
+  font-weight: normal;
+  padding: 0;
+  margin: 2.4rem 0 -0.4rem;
+}
+
+.Doc h1 {
+  font-size: 2.5em;
+}
+.Doc h2 {
+  font-size: 2em;
+}
+.Doc h3 {
+  font-size: 1.5rem;
+}
+.Doc h4 {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+.Doc h5 {
+  font-size: 1rem;
+  font-weight: 700;
+}
+.Doc h6 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.Doc p {
+  margin: 1.2rem 0;
+}
+
+.Doc a {
+  color: var(--dull-turquoise);
+  text-decoration: none;
+}
+
+.Doc a:hover {
+  text-decoration: underline;
+}
+
+.Doc img {
+  max-width: 100%;
+  margin: 0.4rem 0;
+}
+
+.Doc ul,
+.Doc ol {
+  margin: 1.2rem 0;
+  line-height: 1.8;
+  padding-left: 20px;
+}
+
+.Doc code {
+  border-radius: 3px;
+  background-color: rgba(27,31,35,0.05);
+  padding: 0.2rem 0.3rem;
+  margin: 0 -0.1rem;
+  font-size: 85%;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+
+.Doc pre code {
+  margin: 1.8rem 0;
+  padding: 1rem;
+  display: block;
+}
+
+.Doc blockquote {
+  color: var(--dove-gray);
+  padding: .2rem 1rem;
+  margin: 1.2rem 0;
+  border-left: .2rem solid var(--dove-gray);
+}
+
+.Doc blockquote p:first-child {
+  margin-top: 0.25rem;
+}
+
+.Doc blockquote p:last-child {
+  margin-bottom: 0.25rem;
+}
+
+.Doc table {
+  display: block;
+  width: 100%;
+  overflow: auto;
+  margin: 1.8rem 0;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.Doc table tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+.Doc table th {
+  font-weight: 600;
+}
+
+.Doc table th,
+.Doc table td {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e5;
+}
+
+.Doc hr {
+  margin: 2.4rem 0;
+}

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+// Shared styling for in-editor preview, and snapshot rendering.
+import './Doc.css'
+
+const Doc = ({html = '', className = 'Doc', ...props}) => (
+  <div
+    className={className}
+    dangerouslySetInnerHTML={{__html: html}}
+    {...props} />
+)
+
+export default Doc

--- a/src/components/DocViewer.js
+++ b/src/components/DocViewer.js
@@ -1,31 +1,45 @@
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
+import 'normalize.css'
 
 window.ReactDOM = ReactDOM
+
+// Minimal styling so the decrypting messages don't look too old school.
+// This'll be applied to doc too.
+const bodyStyle = {
+  maxWidth: '54rem',
+  margin: '0 auto',
+  padding: '0 10px 50px',
+  fontFamily: `-apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif`
+}
 
 class DocViewer extends Component {
   render () {
     return (
-      <html lang="en">
+      <html lang='en'>
         <head>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+          <meta charSet='utf-8' />
+          <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no' />
           <title>Peerpad doc</title>
         </head>
-        <body>
+        <body style={bodyStyle}>
           <noscript>
             You need to enable JavaScript to get this document.
           </noscript>
-          <div className='container-fluid'>
-            <div id="react-app">Loading and decrypting...</div>
+          <div id='react-app'>
+            <div style={{display: 'table', width: '100%', height: '100vh'}}>
+              <div style={{display: 'table-cell', verticalAlign: 'middle'}}>
+                Loading and decrypting...
+              </div>
+            </div>
           </div>
           <script dangerouslySetInnerHTML={{__html: `
             window.peerpad = {
               encryptedDoc: new Uint8Array([${this.props.encryptedDoc.join(',')}])
             }
           `}} />
-          <script dangerouslySetInnerHTML={{__html: this.props.docScript }} />
+          <script dangerouslySetInnerHTML={{__html: this.props.docScript}} />
         </body>
       </html>
     )
@@ -34,7 +48,7 @@ class DocViewer extends Component {
 
 DocViewer.propTypes = {
   encryptedDoc: PropTypes.object.isRequired,
-  docScript: PropTypes.string.isRequired,
+  docScript: PropTypes.string.isRequired
 }
 
 export default DocViewer

--- a/src/components/DocViewerHTML.js
+++ b/src/components/DocViewerHTML.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 // Hack to minimize source code size of doc snapshot..
 import parseSymmetricalKey from 'peerpad-core/src/backend/keys/parse-symm-key'
+import Doc from './Doc'
 
 class DocViewerHTML extends Component {
-
   constructor (props) {
     super(props)
     this.state = {
@@ -14,11 +14,18 @@ class DocViewerHTML extends Component {
   }
 
   render () {
-    const error = this.state.error && (<p class="error">Error: {this.state.error}</p>)
+    const {
+      error,
+      doc
+    } = this.state
+
     return (
       <div>
-        {error}
-        <div id="doc" dangerouslySetInnerHTML={{__html: (!this.state.error && this.state.doc) || '' }} />
+        {error ? (
+          <p>Error: {this.state.error}</p>
+        ) : (
+          <Doc html={doc} />
+        )}
       </div>
     )
   }
@@ -30,11 +37,11 @@ class DocViewerHTML extends Component {
         if (err) {
           this.setState({error: err.message})
         } else {
-          this.setState({ doc: decrypted.toString('utf8') })
+          this.setState({doc: decrypted.toString('utf8')})
         }
       })
     } catch (err) {
-      this.setState({error: err.message })
+      this.setState({error: err.message})
     }
   }
 }

--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -3,14 +3,6 @@
 .Preview {
   padding-left: 35px;
 }
-.Preview h1,
-.Preview h2,
-.Preview h3,
-.Preview h4,
-.Preview h5,
-.Preview h6 {
-  font-weight: normal;
-}
 .Preview h1::before,
 .Preview h2::before,
 .Preview h3::before,
@@ -43,4 +35,8 @@
 }
 .Preview h6::before {
   content: 'H6';
+}
+
+.Preview > :first-child {
+  margin-top: 0 !important;
 }

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Remark from 'remark'
 import RemarkHtml from 'remark-html'
+import Doc from './Doc'
 import './Preview.css'
 
 const markdown = Remark().use(RemarkHtml)
@@ -31,7 +32,7 @@ export default class Preview extends Component {
   }
 
   render () {
-    return <div className='Preview' dangerouslySetInnerHTML={{__html: this.state.html}} />
+    return <Doc className='Doc Preview' html={this.state.html} />
   }
 }
 


### PR DESCRIPTION
Adds `Doc` component and css to share as much of the document preview styling as is sensible between the in editor preview and a published snapshot of a document.

Adds some eyeball soothing default styles for rendered markdown features and generally improves the look and feel of our docs. 💅 

As time allows I'd like to isolate the preview document styles from the rest of the editor using [css-modules](https://github.com/css-modules/css-modules) or similar, but that is a PR for later.

Fixes #51 


## Editor

![localhost-3000- 17](https://user-images.githubusercontent.com/58871/32055638-48f13dc6-ba5a-11e7-9dfa-192726b024d6.png)


---


## Snapshot

![gateway ipfs io-ipfs-qmptpzfbdj2odz9pphkekh4koanxmnnjx71bhzxgclqs3h-](https://user-images.githubusercontent.com/58871/32055648-4f4f50ea-ba5a-11e7-927c-3210137919c6.png)


