### PR TITLE
Check if local node is already started

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "2.29.0",
     "jest": "20.0.4",
     "object-assign": "4.1.1",
-    "peerpad-core": "^0.4.0",
+    "peerpad-core": "^0.6.0",
     "postcss-css-variables": "^0.8.0",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-import": "^11.0.0",

--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -251,7 +251,11 @@ class Edit extends Component {
       docScript
     })
 
-    this._backend.network.once('started', () => this.setState({ status: 'started' }))
+    if (this._backend.network.hasStarted()) {
+      this.setState({ status: 'online' })
+    } else {
+      this._backend.network.once('started', () => this.setState({ status: 'online' }))
+    }
 
     await doc.start()
 


### PR DESCRIPTION
- Check if local node is already started
- Upgrade to peerpad-core@0.6.0
- Show status as "online" in ui

Fix #58