### PR TITLE
Adding a new type of pad: Math!

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "react-router-hash-link": "^1.1.1",
     "remark": "^8.0.0",
     "remark-html": "^6.0.1",
+    "remark-html-katex": "^1.0.2",
+    "remark-math": "^1.0.1",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.4",
     "tachyons": "^4.8.1",

--- a/src/components/DocViewer.js
+++ b/src/components/DocViewer.js
@@ -23,6 +23,7 @@ class DocViewer extends Component {
           <title>Peerpad doc</title>
           {/* normalize.css@7.0.0 */}
           <link rel='stylesheet' type='text/css' href='https://ipfs.io/ipfs/QmZuSAW5kpxzaidmrpqoWmk8q5Yk7qqpGyxX3zRnRjnRVE' />
+          <link rel='stylesheet' type='text/css' href='https://ipfs.io/ipfs/QmXZCNfBdmdxmoVUF8D7D1EJPeabXxX7yBuzKrnF2AP3Nm/katex.min.css' />
         </head>
         <body style={bodyStyle}>
           <noscript>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -53,7 +53,7 @@ export default class Editor extends Component {
 }
 
 Editor.propTypes = {
-  type: PropTypes.oneOf(['richtext', 'markdown']),
+  type: PropTypes.oneOf(['richtext', 'markdown', 'math']),
   editable: PropTypes.bool,
   onEditor: PropTypes.func,
   onChange: PropTypes.func

--- a/src/components/EditorArea.js
+++ b/src/components/EditorArea.js
@@ -53,7 +53,7 @@ const EditorArea = ({
     )
   }
 
-  const preview = <Preview md={docText} />
+  const preview = <Preview md={docText} type={docType} />
 
   if (viewMode === 'both') {
     return (

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,11 +1,20 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Remark from 'remark'
+import RemarkMath from 'remark-math'
+import RemarkHtmlKatex from 'remark-html-katex'
 import RemarkHtml from 'remark-html'
 import Doc from './Doc'
 import './Preview.css'
+import 'katex/dist/katex.css'
 
-const markdown = Remark().use(RemarkHtml)
+const markdown = Remark()
+  .use(RemarkHtml)
+
+const markdownMath = Remark()
+  .use(RemarkMath)
+  .use(RemarkHtmlKatex)
+  .use(RemarkHtml)
 
 export default class Preview extends Component {
   constructor (props) {
@@ -25,7 +34,13 @@ export default class Preview extends Component {
 
   // TODO: debounce?
   convert (md) {
-    markdown.process(md, (err, html) => {
+    let processor
+    if (this.props.type === 'math') {
+      processor = markdownMath
+    } else {
+      processor = markdown
+    }
+    processor.process(md, (err, html) => {
       if (err) return console.error('Failed to convert markdown to HTML', err)
       this.setState({ html })
     })

--- a/src/components/home/CreateDocument.js
+++ b/src/components/home/CreateDocument.js
@@ -15,6 +15,7 @@ const CreateDocument = ({type, onTypeChange, onCreateDocument}) => (
         onChange={(e) => onTypeChange(e.target.value)}>
         <DocTypeOption text='Markdown pad' value='markdown' />
         <DocTypeOption text='Rich text pad' value='richtext' />
+        <DocTypeOption text='Math pad' value='math' />
       </select>
       <button
         type='button'

--- a/src/components/home/__snapshots__/Home.test.js.snap
+++ b/src/components/home/__snapshots__/Home.test.js.snap
@@ -313,6 +313,22 @@ exports[`can create document via button 1`] = `
                           Rich text pad
                         </option>
                       </DocTypeOption>
+                      <DocTypeOption
+                        text="Math pad"
+                        value="math"
+                      >
+                        <option
+                          className="black"
+                          style={
+                            Object {
+                              "fontSize": "18px",
+                            }
+                          }
+                          value="math"
+                        >
+                          Math pad
+                        </option>
+                      </DocTypeOption>
                     </select>
                     <button
                       className="input-reset bg-caribbean-green ba bw2 b--caribbean-green white f6 fw5 mv2 ph3 pv2 pointer dim tracked--1"

--- a/src/components/toolbar/Toolbar.js
+++ b/src/components/toolbar/Toolbar.js
@@ -36,7 +36,7 @@ const Toolbar = ({
 
 Toolbar.propTypes = {
   theme: PropTypes.oneOf(['light', 'dark']),
-  docType: PropTypes.oneOf(['markdown', 'richtext']).isRequired,
+  docType: PropTypes.oneOf(['markdown', 'richtext', 'math']).isRequired,
   docName: PropTypes.string.isRequired,
   docKeys: PropTypes.shape({
     read: PropTypes.string.isRequired,

--- a/src/components/toolbar/buttons/LinkButton.js
+++ b/src/components/toolbar/buttons/LinkButton.js
@@ -114,7 +114,7 @@ export default class LinkButton extends Component {
 
 LinkButton.propTypes = {
   theme: PropTypes.oneOf(['light', 'dark']),
-  docType: PropTypes.oneOf(['markdown', 'richtext']).isRequired,
+  docType: PropTypes.oneOf(['markdown', 'richtext', 'math']).isRequired,
   docName: PropTypes.string.isRequired,
   docKeys: PropTypes.shape({
     read: PropTypes.string.isRequired,


### PR DESCRIPTION
Equation lovers, this PR is for you!

- I have added a new type of pad called `Math pad`. This supports basic latex via `KaTex`!
- There is now support for `$E = mc^2$` (inline) and `$$y=f(x)$$` (block).
- It works in preview as well!

This PR will only work if the PR on https://github.com/ipfs-shipyard/peerpad-core/pull/2

Related links:
- [Pad with some examples](https://gateway.ipfs.io/ipfs/QmbgcTxNdVnFk4wsvxnovugRXBX8NsiqNBoiv1nVUJhLva/index.html#/w/math/SP8B6HwHQFRpknFbTSxBvA/4XTTM6TKdN4C8g4j7bcoh1M8tQdVbmbr9HFcJ6hhE85MEFTrj/K3TgUEgELeNmzdWrsvRpPbsQuUKzEAwGcHmeFckE2B6yyrsWsJ18aZkrffdgNcqzngqm6GKEbwWzp9uh5WPRi59bhMsv8feYeeK6txSvKxtKkCeTDSZLrQ62b3YdjdDKJpsz46y1)
- [Peerpad with the PR](https://gateway.ipfs.io/ipfs/QmbgcTxNdVnFk4wsvxnovugRXBX8NsiqNBoiv1nVUJhLva/index.html)!

---

Note: this PR is hacky and doesn't have tests :(