### PR TITLE
Setup build + deploy of website for PeerPad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+build:
+	npm install -g yarn
+	yarn
+	yarn build

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,5 @@
+website([
+  website: 'peerpad.net',
+  record: '_dnslink',
+  build_directory: 'build/'
+])


### PR DESCRIPTION
This change gives you a preview of the PeerPad website over IPFS + it'll deploy the hash over at _dnslink.peerpad.net for changes in master. Basically making deploys fully automatic. 