### PR TITLE
fixes #313 - open MD links in separate tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-hash-link": "^1.1.1",
     "remark": "^10.0.1",
+    "remark-external-links": "^5.0.0",
     "remark-html": "^9.0.0",
     "remark-html-katex": "^1.1.1",
     "remark-math": "^1.0.4",

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -1,11 +1,14 @@
 const pify = require('pify')
 const Remark = require('remark')
+const RemarkExternalLinks = require('remark-external-links')
 const RemarkHtml = require('remark-html')
 const RemarkMath = require('remark-math')
 const RemarkHtmlKatex = require('remark-html-katex')
 
 const converters = {
-  markdown: Remark().use(RemarkHtml, { sanitize: true }),
+  markdown: Remark()
+    .use(RemarkHtml, { sanitize: true })
+    .use(RemarkExternalLinks, { rel: false }),
   math: Remark()
     .use(RemarkMath)
     .use(RemarkHtmlKatex)


### PR DESCRIPTION
This PR fixes #313. preview markdown links will open in a separate tab. It uses the remark-external-links plugin for this.